### PR TITLE
Change to non-gendered pronouns in 0.200 announcement

### DIFF
--- a/news/news01.html
+++ b/news/news01.html
@@ -521,9 +521,9 @@ scale as we add new layers and packages to the distribution.
 <div class="outline-text-3" id="text-improved-composability">
 <p>
 The <code>spacemacs</code> distribution layer has been split into several layers under
-the <code>spacemacs</code> directory. The user can now very easily customize her Spacemacs
+the <code>spacemacs</code> directory. The user can now very easily customize their Spacemacs
 experience by choosing the <code>spacemacs-base</code> distribution and using only the
-<code>spacemacs</code> layers she wants.
+<code>spacemacs</code> layers they want.
 </p>
 
 <p>


### PR DESCRIPTION
Current phrasing:

> The user can now very easily customize her Spacemacs experience by choosing the `spacemacs-base` distribution and using only the `spacemacs` layers she wants.

Revised phrasing with gender-neutral pronouns:

> The user can now very easily customize their Spacemacs
> experience by choosing the `spacemacs-base` distribution and using only the
> `spacemacs` layers they want.
