### PR TITLE
Fix grammar in Vim Users documentation

### DIFF
--- a/doc/VIMUSERS.html
+++ b/doc/VIMUSERS.html
@@ -666,7 +666,7 @@ configuration will go in this file.
 <p>
 There are four top-level functions in the file: <code>dotspacemacs/layers</code>,
 <code>dotspacemacs/init</code>, <code>dotspacemacs/user-init</code> and <code>dotspacemacs/user-config</code>.
-The <code>dotspacemacs/layers</code> function exist only to enable and disable layers and
+The <code>dotspacemacs/layers</code> function exists only to enable and disable layers and
 packages. The <code>dotspacemacs/init</code> function is run before anything else during
 startup and contains Spacemacs settings. You will never need to touch this
 function except to change default Spacemacs settings.


### PR DESCRIPTION
Current

> The `dotspacemacs/layers` function **exist** only to enable and disable layers...

New

> The `dotspacemacs/layers` function **exists** only to enable and disable layers...