### PR TITLE
Link beginners tutorial on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,7 @@
         <br>
         <p class="jumbotron-links">
           <a class="nav-link" href="doc/QUICK_START.html">Quick Start</a> &bull;
+          <a class="nav-link" href="doc/BEGINNERS_TUTORIAL.html" target="_blank">  Beginners Tutorial</a> &bull;
           <a class="nav-link" href="doc/DOCUMENTATION.html" target="_blank">  Documentation</a> &bull;
           <a class="nav-link" href="layers/LAYERS.html" target="_blank">  Layers List</a> &bull;
           <a class="nav-link" href="doc/LAYERS.html" target="_blank">  Layers Tutorial</a> &bull;


### PR DESCRIPTION
I chose the spot after quick start since these seemed natural companions: either you're already familiar with Emacs etc and you go to quick start, or these things are new to you and you choose beginner's tutorial.