### PR TITLE
Add a link to the installation guide

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -57,6 +57,13 @@
     color: black;
   }
 
+  #install-btn {
+    display: none;
+    font-size: 50%;
+    padding: 8px;
+    color: black;
+  }
+
   .jumbotron-links {
     text-transform: lowercase;
     font-weight: bold;

--- a/index.html
+++ b/index.html
@@ -86,6 +86,7 @@
         <a class="btn btn-secondary-outline m-b-md" href="#" role="button" id="toggle">&nbsp;<span class="fa fa-arrow-circle-right"></span> Install  &nbsp;</a>
         <pre id="code">git clone https://github.com/syl20bnr/spacemacs ~/.emacs.d</pre>
         <button type="button" name="button" class="btn" id="copy-btn" data-clipboard-target="#code">Copy to clipboard</button>
+        <a href="https://github.com/syl20bnr/spacemacs/blob/master/README.md#install"><button class="btn" id="install-btn">Installation guide</button></a>
         <br>
         <br>
         <p class="jumbotron-links">
@@ -224,6 +225,7 @@
       $("#toggle").click(function() {
         $("#code").fadeToggle("slow");
         $("#copy-btn").fadeToggle("slow");
+        $("#install-btn").fadeToggle("slow");
       })
     </script>
     <script type="text/javascript">


### PR DESCRIPTION
A link to the installation guide has been missing from the spacemacs.org pages, as discussed in https://github.com/syl20bnr/spacemacs/pull/8217. This PR adds a button linking to the installation guide next to the "copy to clipboard" button. The added button appears only when the "Install" button is pressed, appearing next to the "copy to clipboard" button and having the same visual appearance as it.

